### PR TITLE
Fix WS 403: set explicit CORS origins

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -29,7 +29,7 @@ app = FastAPI(title="chatui-backend", version="0.1.0")
 # Local MVP: allow frontend dev server to call backend
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=["http://localhost:5174","http://127.0.0.1:5174","http://localhost:5173","http://127.0.0.1:5173"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
WebSocket connections to `/ws` were being rejected with 403.

Cause: CORSMiddleware + allow_credentials=True + allow_origins=["*"] can reject websocket origins.

Fix: set explicit allowed origins for local dev:
- http://localhost:5173/5174
- http://127.0.0.1:5173/5174

After merge, restart backend and reload frontend.