### PR TITLE
Fix WS 403: CORS wildcard without credentials

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -29,8 +29,8 @@ app = FastAPI(title="chatui-backend", version="0.1.0")
 # Local MVP: allow frontend dev server to call backend
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5174","http://127.0.0.1:5174","http://localhost:5173","http://127.0.0.1:5173"],
-    allow_credentials=True,
+    allow_origins=["*"],
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
WebSocket /ws was still returning 403.

Change CORSMiddleware config to:
- allow_origins=["*"]
- allow_credentials=False

We do not rely on cookies/credentialed requests for MVP, so this is safe for local dev and removes the websocket origin rejection.