### PR TITLE
Issues #13-15: Inline feedback, changelog, PM loop skeleton

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -77,6 +77,24 @@ def db_info():
     return {"db_path": str(Path(DEFAULT_DB_PATH).resolve())}
 
 
+@app.get("/api/changelog")
+def list_changelog(limit: int = 30):
+    if limit < 1 or limit > 200:
+        raise HTTPException(status_code=400, detail="limit must be 1..200")
+    with get_conn() as conn:
+        rows = conn.execute(
+            """
+            SELECT id, title, body_md, created_at
+            FROM changelog_entries
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+
 @app.post("/api/chat")
 def create_chat(payload: ChatCreate):
     with get_conn() as conn:

--- a/backend/db.py
+++ b/backend/db.py
@@ -93,3 +93,36 @@ def init_db(db_path: Path = DEFAULT_DB_PATH) -> None:
         cur.execute(
             "CREATE INDEX IF NOT EXISTS idx_freeform_feedback_created_at ON freeform_feedback(created_at);"
         )
+
+
+        # Changelog entries (what shipped / what happened last run)
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS changelog_entries (
+              id TEXT PRIMARY KEY,
+              title TEXT NOT NULL,
+              body_md TEXT NOT NULL,
+              created_at TEXT NOT NULL
+            );
+            """
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_changelog_entries_created_at ON changelog_entries(created_at DESC);"
+        )
+
+        # PM loop runs (tracks last run + what it did)
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS pm_runs (
+              id TEXT PRIMARY KEY,
+              started_at TEXT NOT NULL,
+              finished_at TEXT,
+              status TEXT NOT NULL,
+              new_feedback_count INTEGER NOT NULL,
+              notes TEXT
+            );
+            """
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pm_runs_started_at ON pm_runs(started_at DESC);"
+        )

--- a/backend/pm_loop.py
+++ b/backend/pm_loop.py
@@ -1,0 +1,103 @@
+"""PM loop skeleton (Issue #15).
+
+Runs locally, checks for new feedback since last run, and if present:
+- writes a daily plan markdown under docs/daily/
+- inserts a changelog entry
+- records a run in pm_runs
+
+No LLM calls yet: plan is a structured placeholder derived from feedback counts.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from db import get_conn, init_db
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DAILY_DIR = REPO_ROOT / "docs" / "daily"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def latest_run_finished_at() -> str | None:
+    with get_conn() as conn:
+        row = conn.execute(
+            "SELECT finished_at FROM pm_runs WHERE finished_at IS NOT NULL ORDER BY finished_at DESC LIMIT 1"
+        ).fetchone()
+        return row[0] if row else None
+
+
+def count_new_feedback(since_iso: str | None) -> int:
+    with get_conn() as conn:
+        if since_iso is None:
+            a = conn.execute("SELECT COUNT(*) FROM answer_feedback").fetchone()[0]
+            f = conn.execute("SELECT COUNT(*) FROM freeform_feedback").fetchone()[0]
+        else:
+            a = conn.execute(
+                "SELECT COUNT(*) FROM answer_feedback WHERE created_at > ?", (since_iso,)
+            ).fetchone()[0]
+            f = conn.execute(
+                "SELECT COUNT(*) FROM freeform_feedback WHERE created_at > ?", (since_iso,)
+            ).fetchone()[0]
+    return int(a) + int(f)
+
+
+def write_daily_plan(feedback_count: int) -> Path:
+    DAILY_DIR.mkdir(parents=True, exist_ok=True)
+    day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    path = DAILY_DIR / f"{day}-plan.md"
+
+    content = f"""# Daily Plan ({day})\n\n## Input\n- New feedback items since last run: **{feedback_count}**\n\n## Proposed work (placeholder)\n- Review new feedback\n- Pick top 1-3 items\n- Draft plan/spec\n- Implement (future)\n- Validate + update changelog\n\n## Notes\nThis is a skeleton plan. Next step: replace placeholder logic with an agent summarizer + GitHub issue triage.\n"""
+    path.write_text(content)
+    return path
+
+
+def insert_changelog_entry(title: str, body_md: str) -> str:
+    entry_id = f"chg_{uuid.uuid4().hex}"
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO changelog_entries(id, title, body_md, created_at) VALUES (?, ?, ?, ?)",
+            (entry_id, title, body_md, now_iso()),
+        )
+    return entry_id
+
+
+def record_run(started_at: str, finished_at: str | None, status: str, new_feedback_count: int, notes: str | None):
+    run_id = f"pm_{uuid.uuid4().hex}"
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO pm_runs(id, started_at, finished_at, status, new_feedback_count, notes) VALUES (?, ?, ?, ?, ?, ?)",
+            (run_id, started_at, finished_at, status, int(new_feedback_count), notes),
+        )
+
+
+def main() -> int:
+    init_db()
+
+    started_at = now_iso()
+    since = latest_run_finished_at()
+    new_count = count_new_feedback(since)
+
+    if new_count <= 0:
+        record_run(started_at, now_iso(), "skipped", 0, "No new feedback")
+        return 0
+
+    plan_path = write_daily_plan(new_count)
+    chg_id = insert_changelog_entry(
+        title="Nightly PM loop ran",
+        body_md=f"Generated plan: `{plan_path.relative_to(REPO_ROOT)}`\n\nNew feedback count: **{new_count}**\n\nChangelog id: `{chg_id}`",
+    )
+
+    record_run(started_at, now_iso(), "ok", new_count, f"plan={plan_path} changelog={chg_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_connectivity.py
+++ b/backend/tests/test_connectivity.py
@@ -108,5 +108,12 @@ class TestConnectivity(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
 
+
+
+    def test_changelog_empty(self):
+        r = self.client.get("/api/changelog?limit=5")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), [])
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/AnswerFeedback.tsx
+++ b/src/AnswerFeedback.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { postJson } from "./api";
+
+export default function AnswerFeedback(props: { chatId: string; messageId: string }) {
+  const { chatId, messageId } = props;
+  const [comment, setComment] = useState("");
+  const [status, setStatus] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const submit = async (thumbs: 1 | -1) => {
+    setSaving(true);
+    setStatus("Saving...");
+    try {
+      await postJson("/api/feedback/answer", {
+        id: `fb_${crypto.randomUUID()}`,
+        chat_id: chatId,
+        message_id: messageId,
+        thumbs,
+        comment: comment.trim() ? comment.trim() : null,
+      });
+      setStatus("Saved");
+      setTimeout(() => setStatus(null), 1500);
+    } catch (e: any) {
+      setStatus(`Error: ${e?.message ?? e}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mt-3">
+      <div className="flex gap-2 items-center">
+        <button type="button" className="px-2 py-1 border rounded hover:bg-gray-50" disabled={saving} onClick={() => submit(1)}>
+          👍
+        </button>
+        <button type="button" className="px-2 py-1 border rounded hover:bg-gray-50" disabled={saving} onClick={() => submit(-1)}>
+          👎
+        </button>
+        <input
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          placeholder="Optional comment…"
+          className="flex-1 p-2 border rounded text-sm"
+        />
+      </div>
+      {status && <div className="text-xs text-gray-600 mt-1">{status}</div>}
+    </div>
+  );
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import { dracula } from "react-syntax-highlighter/dist/esm/styles/prism"
 import "./App.css"
 import { getJson, postJson, BACKEND_HTTP } from "./api"
 import { getOrCreateChatId } from "./chatId"
+import Changelog from "./Changelog"
+import AnswerFeedback from "./AnswerFeedback"
 
 interface Message {
   id?: string
@@ -46,6 +48,7 @@ function App() {
   const [chatId, setChatId] = useState<string | null>(null)
   const [freeformText, setFreeformText] = useState("")
   const [freeformStatus, setFreeformStatus] = useState<string | null>(null)
+  const [view, setView] = useState<"chat" | "changelog">("chat")
 
   const socketRef = useRef<WebSocket | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -159,24 +162,6 @@ function App() {
     setInput("")
   }
 
-  const submitAnswerFeedback = async (message: Message, thumbs: 1 | -1) => {
-    if (!chatId || !message.id) return
-
-    const comment = window.prompt("Optional comment? (leave blank to skip)") ?? ""
-
-    await postJson("/api/feedback/answer", {
-      id: `fb_${crypto.randomUUID()}`,
-      chat_id: chatId,
-      message_id: message.id,
-      thumbs,
-      comment: comment.trim() ? comment.trim() : null,
-    })
-
-    // minimal UI: mark as rated
-    setMessages((prev) =>
-      prev.map((m) => (m.id === message.id ? { ...m, metadata: { ...(m as any).metadata, rated: thumbs } } : m))
-    )
-  }
 
   const submitFreeform = async () => {
     if (!chatId || !freeformText.trim()) return
@@ -218,6 +203,20 @@ function App() {
         </div>
 
         <div className="mt-3 flex gap-2 items-center justify-center">
+          <button
+            type="button"
+            className={`px-3 py-2 rounded-lg border ${view === "chat" ? "bg-gray-900 text-white" : "bg-white"}`}
+            onClick={() => setView("chat")}
+          >
+            Chat
+          </button>
+          <button
+            type="button"
+            className={`px-3 py-2 rounded-lg border ${view === "changelog" ? "bg-gray-900 text-white" : "bg-white"}`}
+            onClick={() => setView("changelog")}
+          >
+            Changelog
+          </button>
           <input
             value={freeformText}
             onChange={(e) => setFreeformText(e.target.value)}
@@ -236,6 +235,11 @@ function App() {
         {freeformStatus && <div className="text-center text-xs text-gray-600 mt-1">{freeformStatus}</div>}
       </header>
 
+      {view === "changelog" ? (
+        <div className="flex-1 overflow-y-auto">
+          <Changelog />
+        </div>
+      ) : (
       <div className="flex-1 overflow-y-auto py-4 space-y-4">
         {messages.map((message, index) => (
           <div key={message.id ?? index} className={`flex flex-col ${message.role === "user" ? "items-end" : "items-start"}`}>
@@ -257,23 +261,8 @@ function App() {
                 )}
                 {message.markdown && <ReactMarkdown components={{ code: CodeBlock }}>{message.markdown}</ReactMarkdown>}
 
-                {message.role === "assistant" && message.id && (
-                  <div className="mt-3 flex gap-2">
-                    <button
-                      type="button"
-                      className="px-2 py-1 border rounded hover:bg-gray-50"
-                      onClick={() => submitAnswerFeedback(message, 1)}
-                    >
-                      👍
-                    </button>
-                    <button
-                      type="button"
-                      className="px-2 py-1 border rounded hover:bg-gray-50"
-                      onClick={() => submitAnswerFeedback(message, -1)}
-                    >
-                      👎
-                    </button>
-                  </div>
+                {message.role === "assistant" && message.id && chatId && (
+                  <AnswerFeedback chatId={chatId} messageId={message.id} />
                 )}
               </div>
             )}
@@ -281,6 +270,7 @@ function App() {
         ))}
         <div ref={messagesEndRef} />
       </div>
+      )}
 
       <form onSubmit={handleSubmit} className="border-t pt-4">
         <div className="flex items-center">

--- a/src/Changelog.tsx
+++ b/src/Changelog.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { getJson } from "./api";
+
+type ChangelogEntry = {
+  id: string;
+  title: string;
+  body_md: string;
+  created_at: string;
+};
+
+export default function Changelog() {
+  const [items, setItems] = useState<ChangelogEntry[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    getJson<ChangelogEntry[]>("/api/changelog?limit=30")
+      .then(setItems)
+      .catch((e) => setErr(e?.message ?? String(e)));
+  }, []);
+
+  if (err) return <div className="p-4 text-sm text-red-600">Failed to load changelog: {err}</div>;
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-3">Changelog</h2>
+      {items.length === 0 ? (
+        <div className="text-sm text-gray-600">No entries yet.</div>
+      ) : (
+        <div className="space-y-3">
+          {items.map((c) => (
+            <div key={c.id} className="border rounded p-3">
+              <div className="flex justify-between gap-3">
+                <div className="font-medium">{c.title}</div>
+                <div className="text-xs text-gray-500">{new Date(c.created_at).toLocaleString()}</div>
+              </div>
+              <pre className="text-sm whitespace-pre-wrap mt-2">{c.body_md}</pre>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Implements:
- #13 inline per-answer feedback comment UI (removes window.prompt)
- #14 changelog backend endpoint + simple UI view
- #15 PM loop skeleton script that writes a daily plan markdown + inserts a changelog entry

Backend:
- `backend/db.py`: adds tables `changelog_entries` and `pm_runs`
- `backend/app.py`: adds `GET /api/changelog`
- `backend/pm_loop.py`: runnable loop skeleton

Frontend:
- Adds a basic view toggle: Chat / Changelog
- Adds `AnswerFeedback` component with inline optional comment

Tests:
- Adds connectivity test for empty changelog.

How to run PM loop:
- `cd backend && source .venv/bin/activate && python pm_loop.py`