### PR TITLE
Add backend unit tests

### DIFF
--- a/backend/pm_loop.py
+++ b/backend/pm_loop.py
@@ -92,7 +92,7 @@ def main() -> int:
     plan_path = write_daily_plan(new_count)
     chg_id = insert_changelog_entry(
         title="Nightly PM loop ran",
-        body_md=f"Generated plan: `{plan_path.relative_to(REPO_ROOT)}`\n\nNew feedback count: **{new_count}**\n\nChangelog id: `{chg_id}`",
+        body_md=f"Generated plan: `{plan_path.relative_to(REPO_ROOT)}`\n\nNew feedback count: **{new_count}**\n\nChangelog id: (this entry)",
     )
 
     record_run(started_at, now_iso(), "ok", new_count, f"plan={plan_path} changelog={chg_id}")

--- a/backend/tests/test_changelog.py
+++ b/backend/tests/test_changelog.py
@@ -1,0 +1,54 @@
+import importlib
+import os
+import tempfile
+import unittest
+
+from fastapi.testclient import TestClient
+
+
+class TestChangelog(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        os.environ["CHATUI_DB_PATH"] = os.path.join(cls._tmp.name, "test.sqlite3")
+
+        import app as app_module  # noqa: E402
+
+        importlib.reload(app_module)
+        cls._app_module = app_module
+        cls.client = TestClient(app_module.app)
+        cls.client.__enter__()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.__exit__(None, None, None)
+        cls._tmp.cleanup()
+
+    def test_changelog_empty(self):
+        r = self.client.get("/api/changelog?limit=5")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), [])
+
+    def test_changelog_ordering(self):
+        # Insert two changelog entries with different created_at ordering.
+        import db
+
+        with db.get_conn() as conn:
+            conn.execute(
+                "INSERT INTO changelog_entries(id, title, body_md, created_at) VALUES (?, ?, ?, ?)",
+                ("c1", "first", "body1", "2026-01-01T00:00:00+00:00"),
+            )
+            conn.execute(
+                "INSERT INTO changelog_entries(id, title, body_md, created_at) VALUES (?, ?, ?, ?)",
+                ("c2", "second", "body2", "2026-02-01T00:00:00+00:00"),
+            )
+
+        r = self.client.get("/api/changelog?limit=10")
+        self.assertEqual(r.status_code, 200)
+        items = r.json()
+        self.assertEqual(items[0]["id"], "c2")
+        self.assertEqual(items[1]["id"], "c1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_db_init.py
+++ b/backend/tests/test_db_init.py
@@ -1,0 +1,45 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestDbInit(unittest.TestCase):
+    def test_init_db_creates_tables(self):
+        tmp = tempfile.TemporaryDirectory()
+        try:
+            db_path = Path(tmp.name) / "t.sqlite3"
+            os.environ["CHATUI_DB_PATH"] = str(db_path)
+
+            # Import after env var set
+            import importlib
+            import db as db_module  # noqa: E402
+
+            importlib.reload(db_module)
+            db_module.init_db(db_module.DEFAULT_DB_PATH)
+
+            conn = sqlite3.connect(str(db_path))
+            try:
+                rows = conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+                ).fetchall()
+                tables = {r[0] for r in rows}
+
+                expected = {
+                    "chats",
+                    "messages",
+                    "answer_feedback",
+                    "freeform_feedback",
+                    "changelog_entries",
+                    "pm_runs",
+                }
+                self.assertTrue(expected.issubset(tables))
+            finally:
+                conn.close()
+        finally:
+            tmp.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_pm_loop.py
+++ b/backend/tests/test_pm_loop.py
@@ -1,0 +1,85 @@
+import importlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestPmLoop(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self._tmp.name, "test.sqlite3")
+        os.environ["CHATUI_DB_PATH"] = self.db_path
+
+        # Import modules after env var is set.
+        import db as db_module
+
+        importlib.reload(db_module)
+        db_module.init_db(db_module.DEFAULT_DB_PATH)
+
+        import pm_loop as pm
+
+        importlib.reload(pm)
+        self.pm = pm
+
+        # Redirect docs/daily output to temp.
+        self.repo_root = Path(self._tmp.name) / "repo"
+        self.repo_root.mkdir(parents=True, exist_ok=True)
+        (self.repo_root / "docs").mkdir(exist_ok=True)
+
+        self.pm.REPO_ROOT = self.repo_root
+        self.pm.DAILY_DIR = self.repo_root / "docs" / "daily"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_skips_when_no_new_feedback(self):
+        rc = self.pm.main()
+        self.assertEqual(rc, 0)
+        self.assertFalse(self.pm.DAILY_DIR.exists())
+
+        import db
+
+        with db.get_conn() as conn:
+            row = conn.execute(
+                "SELECT status, new_feedback_count FROM pm_runs ORDER BY started_at DESC LIMIT 1"
+            ).fetchone()
+            self.assertEqual(row[0], "skipped")
+            self.assertEqual(row[1], 0)
+
+    def test_writes_plan_and_changelog_when_feedback_exists(self):
+        import db
+
+        # Insert one freeform feedback to trigger the run.
+        with db.get_conn() as conn:
+            conn.execute(
+                "INSERT INTO freeform_feedback(id, chat_id, text, created_at, metadata_json) VALUES (?, ?, ?, ?, ?) ",
+                ("ff1", "chat1", "hello", "2026-03-02T00:00:00+00:00", None),
+            )
+
+        rc = self.pm.main()
+        self.assertEqual(rc, 0)
+
+        # Plan file exists
+        self.assertTrue(self.pm.DAILY_DIR.exists())
+        plans = list(self.pm.DAILY_DIR.glob("*-plan.md"))
+        self.assertEqual(len(plans), 1)
+        content = plans[0].read_text()
+        self.assertIn("New feedback items", content)
+
+        # Changelog entry inserted
+        with db.get_conn() as conn:
+            chg = conn.execute(
+                "SELECT id, title FROM changelog_entries ORDER BY created_at DESC LIMIT 1"
+            ).fetchone()
+            self.assertIsNotNone(chg)
+
+            run = conn.execute(
+                "SELECT status, new_feedback_count FROM pm_runs ORDER BY started_at DESC LIMIT 1"
+            ).fetchone()
+            self.assertEqual(run[0], "ok")
+            self.assertGreaterEqual(run[1], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a set of backend unit tests covering:
- DB init creates expected tables
- Changelog endpoint behavior + ordering
- PM loop skeleton behavior (skip/no feedback; writes plan + changelog when feedback exists)

Also fixes a small bug in `pm_loop.py` where body referenced `chg_id` before assignment.

Run:
- `cd backend && source .venv/bin/activate && python -m unittest -v tests.test_db_init tests.test_changelog tests.test_pm_loop tests.test_connectivity`