### PR TITLE
Issues #18-20: backend URL defaults, UI smoke regression, feedback listing

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -230,3 +230,36 @@ async def websocket_endpoint(websocket: WebSocket):
     except WebSocketDisconnect:
         # client disconnected
         return
+
+@app.get("/api/feedback/answer")
+def list_answer_feedback(limit: int = 100):
+    if limit < 1 or limit > 500:
+        raise HTTPException(status_code=400, detail="limit must be 1..500")
+    with get_conn() as conn:
+        rows = conn.execute(
+            """
+            SELECT id, chat_id, message_id, thumbs, comment, created_at, metadata_json
+            FROM answer_feedback
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+@app.get("/api/feedback/freeform")
+def list_freeform_feedback(limit: int = 100):
+    if limit < 1 or limit > 500:
+        raise HTTPException(status_code=400, detail="limit must be 1..500")
+    with get_conn() as conn:
+        rows = conn.execute(
+            """
+            SELECT id, chat_id, text, created_at, metadata_json
+            FROM freeform_feedback
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    return [dict(r) for r in rows]

--- a/backend/tests/test_feedback_list.py
+++ b/backend/tests/test_feedback_list.py
@@ -1,0 +1,63 @@
+import importlib
+import os
+import tempfile
+import unittest
+
+from fastapi.testclient import TestClient
+
+
+class TestFeedbackList(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        os.environ["CHATUI_DB_PATH"] = os.path.join(cls._tmp.name, "test.sqlite3")
+
+        import app as app_module  # noqa: E402
+
+        importlib.reload(app_module)
+        cls.client = TestClient(app_module.app)
+        cls.client.__enter__()
+
+        # seed chat + messages + feedback
+        cls.client.post("/api/chat", json={"chat_id": "chat1"})
+        cls.client.post(
+            "/api/message",
+            json={"id": "m1", "chat_id": "chat1", "role": "assistant", "content": "a"},
+        )
+        cls.client.post(
+            "/api/feedback/answer",
+            json={
+                "id": "afb1",
+                "chat_id": "chat1",
+                "message_id": "m1",
+                "thumbs": 1,
+                "comment": "good",
+            },
+        )
+        cls.client.post(
+            "/api/feedback/freeform",
+            json={"id": "ff1", "chat_id": "chat1", "text": "note"},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.__exit__(None, None, None)
+        cls._tmp.cleanup()
+
+    def test_list_answer_feedback(self):
+        r = self.client.get("/api/feedback/answer?limit=10")
+        self.assertEqual(r.status_code, 200)
+        items = r.json()
+        self.assertGreaterEqual(len(items), 1)
+        self.assertEqual(items[0]["id"], "afb1")
+
+    def test_list_freeform_feedback(self):
+        r = self.client.get("/api/feedback/freeform?limit=10")
+        self.assertEqual(r.status_code, 200)
+        items = r.json()
+        self.assertGreaterEqual(len(items), 1)
+        self.assertEqual(items[0]["id"], "ff1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.0.9",
         "@tailwindcss/typography": "^0.5.10",
         "@types/node": "^22",
@@ -1169,6 +1170,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -6781,6 +6798,53 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.0.9",
     "@tailwindcss/typography": "^0.5.10",
     "@types/node": "^22",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'ui-tests',
+  timeout: 30_000,
+  use: {
+    headless: true,
+    viewport: { width: 1200, height: 800 },
+    baseURL: process.env.PW_BASE_URL || 'http://127.0.0.1:8080',
+  },
+});

--- a/scripts/regression.sh
+++ b/scripts/regression.sh
@@ -26,4 +26,8 @@ python -m unittest -v \
   tests.test_pm_loop \
   tests.test_connectivity
 
-echo "[3/3] Done"
+echo "[3/4] UI smoke"
+cd "$ROOT_DIR"
+./scripts/smoke.sh
+
+echo "[4/4] Done"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+# Ensure playwright is installed
+if [[ ! -d node_modules ]]; then
+  echo "node_modules not found; run npm install first" >&2
+  exit 1
+fi
+
+# Install browser if needed (no sudo)
+if [[ ! -d "$HOME/.cache/ms-playwright" ]]; then
+  echo "Installing Playwright Chromium..." >&2
+  npx playwright install chromium
+fi
+
+# Pick a port unlikely to collide.
+PORT="8090"
+
+# Start backend serving dist/
+cd "$ROOT_DIR/backend"
+if [[ ! -d .venv ]]; then
+  echo "ERROR: backend/.venv not found. Create it first." >&2
+  exit 1
+fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+export FRONTEND_DIST="$ROOT_DIR/dist"
+export CHATUI_DB_PATH="$(mktemp -t chatui-smoke-XXXX.sqlite3)"
+export PW_BASE_URL="http://127.0.0.1:${PORT}/"
+
+uvicorn app:app --host 127.0.0.1 --port "$PORT" >/tmp/chatui-smoke-backend.log 2>&1 &
+BACK_PID=$!
+
+cleanup() {
+  kill "$BACK_PID" >/dev/null 2>&1 || true
+  rm -f "$CHATUI_DB_PATH" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Wait for health
+for i in {1..80}; do
+  if curl -sf "http://127.0.0.1:${PORT}/api/health" >/dev/null; then
+    break
+  fi
+  sleep 0.1
+  if [[ $i -eq 80 ]]; then
+    echo "Backend failed to start. Log:" >&2
+    cat /tmp/chatui-smoke-backend.log >&2 || true
+    exit 1
+  fi
+done
+
+cd "$ROOT_DIR"
+
+npx playwright test

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import ReactMarkdown from "react-markdown"
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter"
 import { dracula } from "react-syntax-highlighter/dist/esm/styles/prism"
 import "./App.css"
-import { getJson, postJson, BACKEND_HTTP } from "./api"
+import { getJson, postJson, backendWsBase } from "./api"
 import { getOrCreateChatId } from "./chatId"
 import Changelog from "./Changelog"
 import AnswerFeedback from "./AnswerFeedback"
@@ -73,7 +73,7 @@ function App() {
 
   // Connect to WebSocket
   useEffect(() => {
-    const socket = new WebSocket(BACKEND_HTTP.replace(/^http/, "ws") + "/ws")
+    const socket = new WebSocket(backendWsBase() + "/ws")
 
     socket.onopen = () => {
       console.log("WebSocket connected")

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,29 @@
-export const BACKEND_HTTP = import.meta.env.VITE_BACKEND_HTTP ?? "http://localhost:8080";
+function defaultBackendHttp(): string {
+  // Prefer an explicit override.
+  const env = (import.meta as any).env?.VITE_BACKEND_HTTP as string | undefined;
+  if (env) return env;
+
+  // If served by backend already (same origin), just use same origin.
+  // Otherwise (Vite dev server on 517x), assume backend is on :8080 on same host.
+  const { protocol, hostname, port } = window.location;
+
+  // If we're already on 8080, use same origin.
+  if (port === "8080") return `${protocol}//${hostname}:${port}`;
+
+  // If no port (e.g. https default 443), also just use same origin.
+  // (This might be a reverse proxy setup.)
+  if (!port) return `${protocol}//${hostname}`;
+
+  // Default dev assumption.
+  return `${protocol}//${hostname}:8080`;
+}
+
+export const BACKEND_HTTP = defaultBackendHttp();
+
+export function backendWsBase(): string {
+  const http = BACKEND_HTTP;
+  return http.replace(/^https:/, "wss:").replace(/^http:/, "ws:");
+}
 
 export async function postJson<T>(path: string, body: unknown): Promise<T> {
   const res = await fetch(`${BACKEND_HTTP}${path}`, {

--- a/ui-tests/smoke.spec.ts
+++ b/ui-tests/smoke.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke: app boots + websocket connects + roundtrip', async ({ page, baseURL }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(String(e)));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+
+  await page.goto(baseURL!, { waitUntil: 'networkidle' });
+
+  // If the app failed to render, surface console errors.
+  const bodyText = await page.locator('body').innerText();
+  if (!bodyText.includes('Chat Interface')) {
+    if (errors.length) throw new Error(`App did not render. Errors:\n${errors.join('\n')}`);
+  }
+
+  await expect(page.getByText('Chat Interface')).toBeVisible({ timeout: 15000 });
+
+  const input = page.getByPlaceholder('Type your message...');
+  await expect(input).toBeEnabled({ timeout: 15000 });
+
+  await input.fill('hello');
+  await input.press('Enter');
+
+  await expect(page.getByText('You said')).toBeVisible({ timeout: 15000 });
+
+  if (errors.length) {
+    throw new Error(`Console/page errors:\n${errors.join('\n')}`);
+  }
+});


### PR DESCRIPTION
Implements:
- #18 derive backend HTTP/WS URL from window.location by default (still supports VITE_BACKEND_HTTP override)
- #19 add headless UI smoke test (Playwright) and wire into scripts/regression.sh
- #20 add backend endpoints to list feedback items (answer + freeform) + unit tests

Notes:
- Added `scripts/smoke.sh` and `ui-tests/smoke.spec.ts`
- Added Playwright config and dev dependency `@playwright/test` (install with --legacy-peer-deps if needed)
- Smoke test runs backend serving `dist/` on port 8090 to avoid collisions

Run:
- `./scripts/regression.sh`