### PR TITLE
MVP: Backlog view

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -79,6 +79,49 @@ def db_info():
     return {"db_path": str(Path(DEFAULT_DB_PATH).resolve())}
 
 
+
+@app.get("/api/backlog")
+def backlog(limit: int = 50):
+    """Return a small backlog snapshot (open GitHub issues).
+
+    Uses GitHub CLI if available/authenticated. If it fails, returns an empty list
+    plus a link to the repo's Issues page.
+    """
+    if limit < 1 or limit > 200:
+        raise HTTPException(status_code=400, detail="limit must be 1..200")
+
+    repo = os.environ.get("GITHUB_REPO", "ninjapapa/chatui")
+    issues_url = f"https://github.com/{repo}/issues"
+
+    try:
+        import subprocess
+
+        res = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "-R",
+                repo,
+                "--state",
+                "open",
+                "--limit",
+                str(limit),
+                "--json",
+                "number,title,url",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        items = json.loads(res.stdout or "[]")
+        if not isinstance(items, list):
+            items = []
+    except Exception:
+        items = []
+
+    return {"repo": repo, "issuesUrl": issues_url, "items": items}
+
 @app.get("/api/changelog")
 def list_changelog(limit: int = 30):
     if limit < 1 or limit > 200:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import "./App.css"
 import { getJson, postJson, backendWsBase } from "./api"
 import { getOrCreateChatId } from "./chatId"
 import Changelog from "./Changelog"
+import Backlog from "./Backlog"
 import AnswerFeedback from "./AnswerFeedback"
 import FeatureRequest from "./FeatureRequest"
 
@@ -49,7 +50,7 @@ function App() {
   const [chatId, setChatId] = useState<string | null>(null)
   const [freeformText, setFreeformText] = useState("")
   const [freeformStatus, setFreeformStatus] = useState<string | null>(null)
-  const [view, setView] = useState<"chat" | "changelog">("chat")
+  const [view, setView] = useState<"chat" | "changelog" | "backlog">("chat")
 
   const socketRef = useRef<WebSocket | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -244,6 +245,10 @@ function App() {
       {view === "changelog" ? (
         <div className="flex-1 overflow-y-auto">
           <Changelog />
+        </div>
+      ) : view === "backlog" ? (
+        <div className="flex-1 overflow-y-auto">
+          <Backlog />
         </div>
       ) : (
       <div className="flex-1 overflow-y-auto py-4 space-y-4">

--- a/src/Backlog.tsx
+++ b/src/Backlog.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { getJson } from "./api";
+
+type BacklogItem = {
+  number: number;
+  title: string;
+  url: string;
+};
+
+type BacklogResponse = {
+  repo: string;
+  issuesUrl: string;
+  items: BacklogItem[];
+};
+
+export default function Backlog() {
+  const [data, setData] = useState<BacklogResponse | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    getJson<BacklogResponse>("/api/backlog")
+      .then(setData)
+      .catch((e) => setErr(e?.message ?? String(e)));
+  }, []);
+
+  if (err) {
+    return (
+      <div className="p-4 text-sm">
+        <div className="text-red-600">Failed to load backlog: {err}</div>
+        <div className="mt-2 text-gray-700">
+          You can still view issues directly on GitHub.
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return <div className="p-4 text-sm text-gray-600">Loading backlog…</div>;
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-3">Backlog</h2>
+      <div className="text-sm mb-3">
+        Repo: <span className="font-mono">{data.repo}</span> ·{" "}
+        <a className="text-blue-600 underline" href={data.issuesUrl} target="_blank" rel="noreferrer">
+          View on GitHub
+        </a>
+      </div>
+
+      {data.items.length === 0 ? (
+        <div className="text-sm text-gray-600">No open issues.</div>
+      ) : (
+        <div className="space-y-2">
+          {data.items.map((it) => (
+            <div key={it.number} className="border rounded p-3">
+              <div className="text-sm font-medium">#{it.number} {it.title}</div>
+              <a className="text-xs text-blue-600 underline" href={it.url} target="_blank" rel="noreferrer">
+                {it.url}
+              </a>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #42.

Adds:
- Backend endpoint GET /api/backlog (uses 42	OPEN	MVP: Backlog view (link to GitHub Issues or list via backend)	enhancement	2026-03-02T23:50:45Z when available; falls back to empty list)
- Frontend Backlog tab that shows open issues (and a link to GitHub Issues).