### PR TITLE
Ops: nightly PM loop scheduling scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,31 @@ source .venv/bin/activate
 FRONTEND_DIST="../dist" uvicorn backend.app:app --reload --port 8080
 ```
 
+## Nightly PM loop
+
+To run the PM loop on-demand (creates/updates GitHub issues from new feedback; skips if none):
+
+```bash
+./scripts/pm_loop_run.sh
+```
+
+To install a nightly cron (default 02:10 local time):
+
+```bash
+./scripts/install_pm_cron.sh
+# optional: pass a custom cron schedule, e.g.
+./scripts/install_pm_cron.sh "0 1 * * *"
+```
+
+To uninstall:
+
+```bash
+./scripts/uninstall_pm_cron.sh
+```
+
+Logs:
+- `backend/data/pm_loop.log`
+
 ## Tests
 
 ### One-command (recommended)

--- a/scripts/install_pm_cron.sh
+++ b/scripts/install_pm_cron.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs a user crontab entry to run the PM loop nightly.
+# Default schedule: 02:10 local time.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCHEDULE="${1:-"10 2 * * *"}"
+
+JOB_CMD="cd $ROOT_DIR && $ROOT_DIR/scripts/pm_loop_run.sh >> $ROOT_DIR/backend/data/pm_loop.log 2>&1"
+JOB_LINE="$SCHEDULE $JOB_CMD"
+
+mkdir -p "$ROOT_DIR/backend/data"
+
+# Get current crontab (if any)
+TMP="$(mktemp)"
+crontab -l 2>/dev/null >"$TMP" || true
+
+# If already present, do nothing.
+if grep -Fq "$ROOT_DIR/scripts/pm_loop_run.sh" "$TMP"; then
+  echo "Cron already contains a pm_loop_run.sh entry. No changes made." >&2
+  rm -f "$TMP"
+  exit 0
+fi
+
+{
+  cat "$TMP"
+  echo ""
+  echo "# chatui: nightly PM loop (skip if no new feedback)"
+  echo "$JOB_LINE"
+} | crontab -
+
+rm -f "$TMP"
+
+echo "Installed cron entry:" >&2
+echo "$JOB_LINE" >&2

--- a/scripts/pm_loop_run.sh
+++ b/scripts/pm_loop_run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR/backend"
+
+if [[ ! -d .venv ]]; then
+  echo "ERROR: backend/.venv not found. Create it first:" >&2
+  echo "  cd backend && python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+# Run PM loop (idempotent; skips if no new feedback)
+python pm_loop_gh.py

--- a/scripts/uninstall_pm_cron.sh
+++ b/scripts/uninstall_pm_cron.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TMP="$(mktemp)"
+crontab -l 2>/dev/null >"$TMP" || true
+
+grep -vF "$ROOT_DIR/scripts/pm_loop_run.sh" "$TMP" | crontab -
+rm -f "$TMP"
+
+echo "Removed cron entries containing: $ROOT_DIR/scripts/pm_loop_run.sh" >&2


### PR DESCRIPTION
Fixes #49.

Adds:
- scripts/pm_loop_run.sh: runs backend/pm_loop_gh.py using backend/.venv
- scripts/install_pm_cron.sh: installs a user crontab entry (default 02:10 local time) and logs to backend/data/pm_loop.log
- scripts/uninstall_pm_cron.sh
- README docs for running on-demand + installing cron

Note: This PR does not auto-install cron; it provides the scripts + docs.