### PR TITLE
MVP: local rollback mechanism for frontend builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ backend/data/
 # Node
 node_modules/
 dist/
+dist-releases/

--- a/README.md
+++ b/README.md
@@ -163,6 +163,36 @@ npm run smoke
 npm run regression
 ```
 
+## Rollback (local)
+
+Frontend builds can be versioned for quick rollback.
+
+Create a new release (builds + updates the dist symlink):
+
+```bash
+./scripts/release_build.sh
+```
+
+List releases:
+
+```bash
+./scripts/releases_list.sh
+```
+
+Switch to a previous release:
+
+```bash
+./scripts/releases_use.sh <timestamp>
+```
+
+Prune old releases (keep newest N, default 5):
+
+```bash
+./scripts/releases_prune.sh 5
+```
+
+Tip: when running the backend to serve the built UI, it uses dist/ (which is a symlink to the active release).
+
 ## Notes
 
 - The existing codebase may contain leftover UI/components from the original project. We’ll replace/reshape incrementally.

--- a/scripts/release_build.sh
+++ b/scripts/release_build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the frontend and keep timestamped releases for quick rollback.
+# Maintains:
+# - dist-releases/<timestamp>/ (immutable builds)
+# - dist -> dist-releases/<timestamp> (symlink)
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+TS="$(date +%Y%m%d-%H%M%S)"
+RELEASE_DIR="$ROOT_DIR/dist-releases/$TS"
+
+mkdir -p "$ROOT_DIR/dist-releases"
+
+npm run build
+
+if [[ ! -d "$ROOT_DIR/dist" ]]; then
+  echo "ERROR: dist/ not found after build" >&2
+  exit 1
+fi
+
+mv "$ROOT_DIR/dist" "$RELEASE_DIR"
+ln -sfn "$RELEASE_DIR" "$ROOT_DIR/dist"
+
+echo "Release created: $RELEASE_DIR" >&2

--- a/scripts/releases_list.sh
+++ b/scripts/releases_list.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIR="$ROOT_DIR/dist-releases"
+
+if [[ ! -d "$DIR" ]]; then
+  echo "No releases yet (missing dist-releases/)" >&2
+  exit 0
+fi
+
+ls -1 "$DIR" | sort

--- a/scripts/releases_prune.sh
+++ b/scripts/releases_prune.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep the newest N releases (default 5) and delete the rest.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KEEP="${1:-5}"
+DIR="$ROOT_DIR/dist-releases"
+
+if [[ ! -d "$DIR" ]]; then
+  echo "No releases to prune (missing dist-releases/)" >&2
+  exit 0
+fi
+
+mapfile -t items < <(ls -1 "$DIR" | sort)
+count=${#items[@]}
+
+if (( count <= KEEP )); then
+  echo "Nothing to prune (count=$count <= keep=$KEEP)" >&2
+  exit 0
+fi
+
+remove=$((count-KEEP))
+for ((i=0; i<remove; i++)); do
+  rm -rf "$DIR/${items[$i]}"
+  echo "Removed $DIR/${items[$i]}" >&2
+done

--- a/scripts/releases_use.sh
+++ b/scripts/releases_use.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REL="${1:-}"
+
+if [[ -z "$REL" ]]; then
+  echo "Usage: ./scripts/releases_use.sh <timestamp>" >&2
+  echo "See available releases: ./scripts/releases_list.sh" >&2
+  exit 2
+fi
+
+TARGET="$ROOT_DIR/dist-releases/$REL"
+if [[ ! -d "$TARGET" ]]; then
+  echo "ERROR: release not found: $TARGET" >&2
+  exit 1
+fi
+
+ln -sfn "$TARGET" "$ROOT_DIR/dist"
+
+echo "Now using dist -> $TARGET" >&2


### PR DESCRIPTION
Fixes #50.

Adds a simple local release/rollback mechanism for the built frontend:
- dist-releases/<timestamp>/ stores immutable build outputs
- dist is a symlink to the active release

Scripts:
- ./scripts/release_build.sh
- ./scripts/releases_list.sh
- ./scripts/releases_use.sh <timestamp>
- ./scripts/releases_prune.sh [keep]

Docs:
- README updated
- dist-releases/ added to .gitignore