### PR TITLE
MVP(local): small finishing touches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Frontend/backend shared env (local)
+
+# LLM
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+
+# Grounded citations (optional)
+# If set, backend will use Brave Search to retrieve sources and cite them.
+BRAVE_API_KEY=
+CHATUI_SEARCH_COUNT=5
+
+# GitHub PM loop
+GITHUB_REPO=ninjapapa/chatui

--- a/README.md
+++ b/README.md
@@ -66,7 +66,27 @@ The system should behave like a product that evolves continuously based on actua
 - **Backend:** FastAPI (local MVP)
 - **Storage:** SQLite (see `docs/DECISIONS.md`)
 
+## MVP done (local)
+
+Checklist:
+- [ ] Frontend runs locally (`npm run dev`)
+- [ ] Backend runs locally (see Backend section)
+- [ ] Chat works end-to-end (WS connected; responses returned)
+- [ ] Feedback can be submitted (per-answer + free-form)
+- [ ] Changelog page loads
+- [ ] Backlog page loads
+- [ ] Grounded citations enabled (optional): set `BRAVE_API_KEY`
+- [ ] PM loop can run on-demand (`./scripts/pm_loop_run.sh`)
+- [ ] Rollback works (`./scripts/release_build.sh` + `./scripts/releases_use.sh`)
+
 ## Local dev
+
+Copy env template (optional):
+
+```bash
+cp .env.example .env
+```
+
 
 ### 1) Frontend dev server
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -31,7 +31,13 @@ app = FastAPI(title="chatui-backend", version="0.1.0")
 # Local MVP: allow frontend dev server to call backend
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    # Local-first default: allow Vite dev server + same-origin.
+    # Set CHATUI_CORS_ALLOW_ALL=1 to allow all origins (not recommended beyond local).
+    allow_origins=(
+        ["*"]
+        if os.environ.get("CHATUI_CORS_ALLOW_ALL") == "1"
+        else ["http://localhost:5173", "http://127.0.0.1:5173"]
+    ),
     allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -122,6 +128,24 @@ def backlog(limit: int = 50):
 
     return {"repo": repo, "issuesUrl": issues_url, "items": items}
 
+
+
+@app.get("/api/pm/status")
+def pm_status():
+    """Return last PM run info + log location (local)."""
+    with get_conn() as conn:
+        row = conn.execute(
+            """
+            SELECT id, started_at, finished_at, status, new_feedback_count, notes
+            FROM pm_runs
+            ORDER BY started_at DESC
+            LIMIT 1
+            """
+        ).fetchone()
+
+    last = dict(row) if row else None
+    log_path = str((REPO_ROOT / "backend" / "data" / "pm_loop.log").resolve())
+    return {"last": last, "logPath": log_path}
 @app.get("/api/changelog")
 def list_changelog(limit: int = 30):
     if limit < 1 or limit > 200:

--- a/scripts/setup_labels.sh
+++ b/scripts/setup_labels.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create helpful labels for PM loop triage (idempotent).
+# Safe to run multiple times.
+
+REPO="${GITHUB_REPO:-ninjapapa/chatui}"
+
+ensure_label() {
+  local name="$1" color="$2" desc="$3"
+  if gh label list -R "$REPO" --limit 200 | awk -F'\t' '{print $1}' | grep -Fxq "$name"; then
+    echo "label exists: $name" >&2
+    return 0
+  fi
+  gh label create "$name" -R "$REPO" -c "$color" -d "$desc" || true
+}
+
+ensure_label "feedback" "5319e7" "User feedback / product feedback"
+ensure_label "feature" "0e8a16" "Feature request"

--- a/src/Backlog.tsx
+++ b/src/Backlog.tsx
@@ -13,14 +13,32 @@ type BacklogResponse = {
   items: BacklogItem[];
 };
 
+type PmStatus = {
+  last: {
+    id: string;
+    started_at: string;
+    finished_at: string | null;
+    status: string;
+    new_feedback_count: number;
+    notes: string | null;
+  } | null;
+  logPath: string;
+};
+
+
 export default function Backlog() {
   const [data, setData] = useState<BacklogResponse | null>(null);
+  const [pm, setPm] = useState<PmStatus | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
     getJson<BacklogResponse>("/api/backlog")
       .then(setData)
       .catch((e) => setErr(e?.message ?? String(e)));
+
+    getJson<PmStatus>("/api/pm/status")
+      .then(setPm)
+      .catch(() => {});
   }, []);
 
   if (err) {
@@ -44,6 +62,18 @@ export default function Backlog() {
         <a className="text-blue-600 underline" href={data.issuesUrl} target="_blank" rel="noreferrer">
           View on GitHub
         </a>
+      </div>
+
+      <div className="text-xs text-gray-600 mb-3">
+        <div className="font-medium">PM loop</div>
+        {pm?.last ? (
+          <div>
+            Last run: {new Date(pm.last.started_at).toLocaleString()} · status: {pm.last.status} · new feedback: {pm.last.new_feedback_count}
+          </div>
+        ) : (
+          <div>No PM runs yet.</div>
+        )}
+        <div>Log: <span className="font-mono">{pm?.logPath ?? "backend/data/pm_loop.log"}</span></div>
       </div>
 
       {data.items.length === 0 ? (


### PR DESCRIPTION
Small local-MVP finishing touches:

- .env.example for local configuration (OpenAI, Brave search, GitHub repo)
- Backend: safer default CORS (allows Vite dev server only; CHATUI_CORS_ALLOW_ALL=1 to override)
- Backend: /api/pm/status endpoint to show last PM run + log path
- UI: Backlog page shows PM loop last run + log path
- scripts/setup_labels.sh: optional helper to create feedback/feature labels
- README: add a simple 'MVP done (local)' checklist + mention env template